### PR TITLE
Pass securitystamp time on singout

### DIFF
--- a/src/UserImmediateActions/Stores/IImmediateActionsStore.cs
+++ b/src/UserImmediateActions/Stores/IImmediateActionsStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using UserImmediateActions.Models;
@@ -10,18 +11,20 @@ namespace UserImmediateActions.Stores
         /// Adds given <paramref name="key"/> to the underlying store.
         /// </summary>
         /// <param name="key">The unique key to store.</param>
+        /// <param name="expirationTime">Expiration time relative to now.</param>
         /// <param name="data">The data to add to the underlying store.</param>
         /// <returns><see cref="Task"/></returns>
-        void Add(string key, ImmediateActionDataModel data);
+        void Add(string key, TimeSpan expirationTime, ImmediateActionDataModel data);
 
         /// <summary>
         /// Adds given <paramref name="key"/> to the underlying store asynchronously.
         /// </summary>
         /// <param name="key">The unique key to store.</param>
+        /// <param name="expirationTime">Expiration time relative to now.</param>
         /// <param name="data">The data to add to the underlying store.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
         /// <returns><see cref="Task"/></returns>
-        Task AddAsync(string key, ImmediateActionDataModel data, CancellationToken cancellationToken = default);
+        Task AddAsync(string key, TimeSpan expirationTime, ImmediateActionDataModel data, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// If key is found in the underlying store, its <see cref="AddPurpose"/> will be returned, else will return <c>null</c>.

--- a/src/UserImmediateActions/Stores/MemoryCacheImmediateActionsStore.cs
+++ b/src/UserImmediateActions/Stores/MemoryCacheImmediateActionsStore.cs
@@ -1,53 +1,47 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Options;
 using UserImmediateActions.Models;
 
 namespace UserImmediateActions.Stores
 {
     public class MemoryCacheImmediateActionsStore : IImmediateActionsStore
     {
+        private readonly IDateTimeProvider _dateTimeProvider;
         private readonly IMemoryCache _memoryCache;
         private readonly IPermanentImmediateActionsStore _permanentImmediateActionsStore;
-        private readonly IDateTimeProvider _dateTimeProvider;
-        private readonly TimeSpan _defaultExpirationRelativeToNow;
 
         public MemoryCacheImmediateActionsStore(IMemoryCache memoryCache,
             IPermanentImmediateActionsStore permanentImmediateActionsStore,
-            IDateTimeProvider dateTimeProvider,
-            IOptions<CookieAuthenticationOptions> options)
+            IDateTimeProvider dateTimeProvider)
         {
             _memoryCache = memoryCache;
             _permanentImmediateActionsStore = permanentImmediateActionsStore;
             _dateTimeProvider = dateTimeProvider;
-            var cookieAuthenticationOptions = options?.Value ?? new CookieAuthenticationOptions();
-            _defaultExpirationRelativeToNow = cookieAuthenticationOptions.ExpireTimeSpan;
         }
 
-        public void Add(string key, ImmediateActionDataModel data)
+        public void Add(string key, TimeSpan expirationTime, ImmediateActionDataModel data)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentException("Value cannot be null or empty.", nameof(key));
 
             _permanentImmediateActionsStore.Add(key,
-                _dateTimeProvider.Now().Add(_defaultExpirationRelativeToNow),
+                _dateTimeProvider.Now().Add(expirationTime),
                 data);
 
-            _memoryCache.Set(key, data, absoluteExpirationRelativeToNow: _defaultExpirationRelativeToNow);
+            _memoryCache.Set(key, data, expirationTime);
         }
 
-        public async Task AddAsync(string key, ImmediateActionDataModel data, CancellationToken cancellationToken = default)
+        public async Task AddAsync(string key, TimeSpan expirationTime, ImmediateActionDataModel data, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentException("Value cannot be null or empty.", nameof(key));
 
             await _permanentImmediateActionsStore.AddAsync(key,
-                _dateTimeProvider.Now().Add(_defaultExpirationRelativeToNow),
+                _dateTimeProvider.Now().Add(expirationTime),
                 data,
                 cancellationToken);
 
-            Add(key, data);
+            Add(key, expirationTime, data);
         }
 
         public ImmediateActionDataModel Get(string key)

--- a/src/UserImmediateActions/UserImmediateActionsService.cs
+++ b/src/UserImmediateActions/UserImmediateActionsService.cs
@@ -46,7 +46,7 @@ namespace UserImmediateActions
             if (string.IsNullOrEmpty(userId)) throw new ArgumentException("Value cannot be null or empty.", nameof(userId));
 
             var key = _userActionStoreKeyGenerator.GenerateKey(userId);
-            await _immediateActionsStore.AddAsync(key, _expirationTimeForSignOut, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.RefreshCookie),
+            await _immediateActionsStore.AddAsync(key, _expirationTimeForRefreshCookie, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.RefreshCookie),
                 cancellationToken);
         }
 
@@ -56,7 +56,7 @@ namespace UserImmediateActions
 
             var key = _userActionStoreKeyGenerator.GenerateKey(userId);
 
-            _immediateActionsStore.Add(key, _expirationTimeForRefreshCookie, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.SignOut));
+            _immediateActionsStore.Add(key, _expirationTimeForSignOut, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.SignOut));
         }
 
         public async Task SignOutAsync(string userId, CancellationToken cancellationToken = default)

--- a/src/UserImmediateActions/UserImmediateActionsService.cs
+++ b/src/UserImmediateActions/UserImmediateActionsService.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
 using UserImmediateActions.Models;
 using UserImmediateActions.Stores;
 
@@ -8,15 +11,25 @@ namespace UserImmediateActions
 {
     public class UserImmediateActionsService : IUserImmediateActionsService
     {
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly TimeSpan _expirationTimeForRefreshCookie;
+        private readonly TimeSpan _expirationTimeForSignOut;
         private readonly IImmediateActionsStore _immediateActionsStore;
         private readonly IUserActionStoreKeyGenerator _userActionStoreKeyGenerator;
-        private readonly IDateTimeProvider _dateTimeProvider;
 
-        public UserImmediateActionsService(IImmediateActionsStore immediateActionsStore, IUserActionStoreKeyGenerator userActionStoreKeyGenerator, IDateTimeProvider dateTimeProvider)
+        public UserImmediateActionsService(IImmediateActionsStore immediateActionsStore,
+            IUserActionStoreKeyGenerator userActionStoreKeyGenerator,
+            IDateTimeProvider dateTimeProvider,
+            IOptions<CookieAuthenticationOptions> cookieAuthenticationOptions,
+            IOptions<SecurityStampValidatorOptions> securityStampValidatorOptions)
         {
             _immediateActionsStore = immediateActionsStore;
             _userActionStoreKeyGenerator = userActionStoreKeyGenerator;
             _dateTimeProvider = dateTimeProvider;
+            var cookieOptions = cookieAuthenticationOptions?.Value ?? new CookieAuthenticationOptions();
+            _expirationTimeForRefreshCookie = cookieOptions.ExpireTimeSpan;
+            var securityStampOptions = securityStampValidatorOptions?.Value ?? new SecurityStampValidatorOptions();
+            _expirationTimeForSignOut = securityStampOptions.ValidationInterval;
         }
 
         public void RefreshCookie(string userId)
@@ -24,8 +37,8 @@ namespace UserImmediateActions
             if (string.IsNullOrEmpty(userId)) throw new ArgumentException("Value cannot be null or empty.", nameof(userId));
 
             var key = _userActionStoreKeyGenerator.GenerateKey(userId);
-            
-            _immediateActionsStore.Add(key, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.RefreshCookie));
+
+            _immediateActionsStore.Add(key, _expirationTimeForRefreshCookie, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.RefreshCookie));
         }
 
         public async Task RefreshCookieAsync(string userId, CancellationToken cancellationToken = default)
@@ -33,7 +46,8 @@ namespace UserImmediateActions
             if (string.IsNullOrEmpty(userId)) throw new ArgumentException("Value cannot be null or empty.", nameof(userId));
 
             var key = _userActionStoreKeyGenerator.GenerateKey(userId);
-            await _immediateActionsStore.AddAsync(key, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.RefreshCookie), cancellationToken);
+            await _immediateActionsStore.AddAsync(key, _expirationTimeForSignOut, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.RefreshCookie),
+                cancellationToken);
         }
 
         public void SignOut(string userId)
@@ -41,7 +55,8 @@ namespace UserImmediateActions
             if (string.IsNullOrEmpty(userId)) throw new ArgumentException("Value cannot be null or empty.", nameof(userId));
 
             var key = _userActionStoreKeyGenerator.GenerateKey(userId);
-            _immediateActionsStore.Add(key, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.SignOut));
+
+            _immediateActionsStore.Add(key, _expirationTimeForRefreshCookie, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.SignOut));
         }
 
         public async Task SignOutAsync(string userId, CancellationToken cancellationToken = default)
@@ -49,7 +64,7 @@ namespace UserImmediateActions
             if (string.IsNullOrEmpty(userId)) throw new ArgumentException("Value cannot be null or empty.", nameof(userId));
 
             var key = _userActionStoreKeyGenerator.GenerateKey(userId);
-            await _immediateActionsStore.AddAsync(key, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.SignOut), cancellationToken);
+            await _immediateActionsStore.AddAsync(key, _expirationTimeForSignOut, new ImmediateActionDataModel(_dateTimeProvider.Now(), AddPurpose.SignOut), cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Now will pass security stamp validation interval ( in `SecurityStampValidatorOptions` class ) to the underlying store when `SignOut` or `SignOutAsync` methods of `IUserImmediateActionsService` is called.